### PR TITLE
Sentiment analysis

### DIFF
--- a/conf/server-mpnet.conf
+++ b/conf/server-mpnet.conf
@@ -28,3 +28,6 @@ threshold = 0.98
 
 [scanner:similarity]
 threshold = 0.4
+
+[scanner:sentiment]
+threshold = 0.7

--- a/conf/server-openai.conf
+++ b/conf/server-openai.conf
@@ -28,3 +28,6 @@ threshold = 0.98
 
 [scanner:similarity]
 threshold = 0.4
+
+[scanner:sentiment]
+threshold = 0.7

--- a/conf/server.conf
+++ b/conf/server.conf
@@ -28,3 +28,6 @@ threshold = 0.98
 
 [scanner:similarity]
 threshold = 0.4
+
+[scanner:sentiment]
+threshold = 0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ chromadb==0.4.8
 streamlit==1.26.0
 numpy==1.25.2
 loguru==0.7.2
+nltk==3.8.1

--- a/vigil-server.py
+++ b/vigil-server.py
@@ -323,7 +323,7 @@ if __name__ == '__main__':
         'transformer': setup_transformer_scanner,
         'yara': setup_yara_scanner,
         'vectordb': setup_vectordb_scanner,
-        'sentiment': setup_sentinel_scanner
+        'sentiment': setup_sentiment_scanner
     }
 
     for name in out_scanners:

--- a/vigil-server.py
+++ b/vigil-server.py
@@ -60,7 +60,7 @@ def setup_yara_scanner(conf):
     return yara_scanner
 
 
-def setup_sentinel_scanner(conf):
+def setup_sentiment_scanner(conf):
     return SentimentScanner(
         config_dict={
             'threshold': float(conf.get_val('scanner:sentiment', 'threshold'))

--- a/vigil-server.py
+++ b/vigil-server.py
@@ -15,6 +15,7 @@ from vigil.scanners.yara import YaraScanner
 from vigil.scanners.vectordb import VectorScanner
 from vigil.scanners.transformer import TransformerScanner
 from vigil.scanners.similarity import SimilarityScanner
+from vigil.scanners.sentiment import SentimentScanner
 
 from vigil.canary import CanaryTokens
 from vigil.vectordb import VectorDB
@@ -57,6 +58,14 @@ def setup_yara_scanner(conf):
     yara_scanner = YaraScanner(config_dict={'rules_dir': yara_dir})
     yara_scanner.load_rules()
     return yara_scanner
+
+
+def setup_sentinel_scanner(conf):
+    return SentimentScanner(
+        config_dict={
+            'threshold': float(conf.get_val('scanner:sentiment', 'threshold'))
+        }
+    )
 
 
 def setup_vectordb_scanner(conf):
@@ -313,7 +322,8 @@ if __name__ == '__main__':
         'similarity': setup_similarity_scanner,
         'transformer': setup_transformer_scanner,
         'yara': setup_yara_scanner,
-        'vectordb': setup_vectordb_scanner
+        'vectordb': setup_vectordb_scanner,
+        'sentiment': setup_sentinel_scanner
     }
 
     for name in out_scanners:

--- a/vigil/scanners/sentiment.py
+++ b/vigil/scanners/sentiment.py
@@ -1,0 +1,50 @@
+import uuid
+import nltk
+
+from loguru import logger
+
+from nltk.sentiment import SentimentIntensityAnalyzer
+
+from vigil.schema import BaseScanner
+from vigil.schema import ScanModel
+from vigil.schema import SentimentMatch
+
+
+nltk.download('vader_lexicon')
+
+
+class SentimentScanner(BaseScanner):
+    def __init__(self, config_dict: dict):
+        self.name = 'scanner:sentiment'
+        self.threshold = float(config_dict['threshold'])
+        self.analyzer = SentimentIntensityAnalyzer()
+        logger.info('Loaded scanner.')
+
+    def analyze(self, scan_obj: ScanModel, scan_id: uuid.uuid4) -> ScanModel:
+        logger.info(f'Performing scan; id="{scan_id}"')
+
+        # this scanner can be used on both prompts and responses
+        # so we need to check which one we're working with
+        prompt = scan_obj.prompt if scan_obj.prompt_response is None else scan_obj.prompt_response
+
+        try:
+            scores = self.analyzer.polarity_scores(prompt)
+            logger.info(f'Sentiment scores: {scores} id="{scan_id}"')
+
+            if scores['neg'] > self.threshold:
+                logger.info(f'Negative sentiment score above threshold; threshold={self.threshold} id="{scan_id}"')
+
+            scan_obj.results.append(
+                SentimentMatch(
+                    threshold=self.threshold,
+                    compound=scores['compound'],
+                    negative=scores['neg'],
+                    neutral=scores['neu'],
+                    positive=scores['pos']
+                )
+            )
+        except Exception as err:
+            logger.error(f'Analyzer error: {err} id="{scan_id}"')
+            return scan_obj
+
+        return scan_obj

--- a/vigil/schema.py
+++ b/vigil/schema.py
@@ -56,3 +56,11 @@ class SimilarityMatch(BaseModel):
     score: float = 0.0
     threshold: float = 0.0
     message: str = ''
+
+
+class SentimentMatch(BaseModel):
+    negative: float = 0.0
+    neutral: float = 0.0
+    positive: float = 0.0
+    compound: float = 0.0
+    threshold: float = 0.0


### PR DESCRIPTION
**Sentiment analysis**
- Add sentiment analysis scanner
- Disabled by default in API server
- Can be used as input/output scanner or both
- Negative sentiment threshold can be configured in `conf/server.conf`
- Results store all sentiment scores