### PR TITLE
Data loader using existing setup functions

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -1,57 +1,13 @@
 import os
 import sys
-import json
 import argparse
-
-from datasets import load_dataset
 
 from loguru import logger
 
 from vigil.core.config import Config
-from vigil.core.vectordb import VectorDB
+from vigil.core.loader import Loader
 
-
-class Loader:
-    def __init__(self, vector_db, chunk_size=100):
-        self.vector_db = vector_db
-        self.chunk_size = chunk_size
-
-    def load_dataset(self, dataset_name: str):
-        buffer = []
-
-        logger.info(f'Loading dataset: {dataset_name}')
-        try:
-            docs_stream = load_dataset(
-                dataset_name,
-                split='train',
-                streaming=True)
-        except Exception as err:
-            logger.error(f'Error loading dataset: {err}')
-            raise
-
-        logger.info('Reading dataset stream ...')
-
-        for doc in docs_stream:
-            buffer.append({
-                'text': doc['text'],
-                'embeddings': doc['embeddings'],
-                'metadata': {'model': doc['model']}
-            })
-            if len(buffer) >= self.chunk_size:
-                self.process_chunk(buffer)
-                buffer.clear()
-
-        if buffer:
-            self.process_chunk(buffer)
-        
-        logger.info('Finished loading dataset.')
-
-    def process_chunk(self, chunk):
-        texts = [doc['text'] for doc in chunk]
-        embeddings = [doc['embeddings'] for doc in chunk]
-        metadatas = [doc['metadata'] for doc in chunk]
-        self.vector_db.add_embeddings(texts, embeddings, metadatas)
-        logger.info(f'Processed chunk; {len(chunk)}')
+from vigil.vigil import setup_vectordb
 
 
 if __name__ == "__main__":
@@ -77,47 +33,11 @@ if __name__ == "__main__":
 
     conf = Config(args.config)
 
-    # read vectordb config
-    vdb_dir = conf.get_val('scanner:vectordb', 'db_dir')
-    vdb_collection = conf.get_val('scanner:vectordb', 'collection')
-    n_results = conf.get_val('scanner:vectordb', 'n_results')
+    embedding_conf = conf.get_general_config().get('embedding', {})
+    scanner_conf = conf.get_scanner_config('vectordb')
 
-    logger.info(f'using database directory: {vdb_dir}')
-
-    if not os.path.isdir(vdb_dir):
-        logger.error(f'VectorDB directory not found: {vdb_dir}')
-        sys.exit(1)
-
-    # text embedding model
-    emb_model = conf.get_val('embedding', 'model')
-    if emb_model is None:
-        logger.warn('No embedding model set in config file')
-        sys.exit(1)
-
-    if emb_model == 'openai':
-        openai_key = conf.get_val('embedding', 'openai_api_key')
-        openai_model = conf.get_val('embedding', 'openai_model')
-
-        if openai_key is None or openai_model is None:
-            logger.error('OpenAI embedding model selected but no key or model name set in config')
-            sys.exit(1)
-
-        vdb = VectorDB(config_dict={
-            'collection_name': vdb_collection,
-            'embed_fn': 'openai',
-            'openai_key': openai_key,
-            'openai_model': openai_model,
-            'db_dir': vdb_dir,
-            'n_results': n_results
-        })
-
-    else:
-        vdb = VectorDB(config_dict={
-            'collection_name': vdb_collection,
-            'embed_fn': emb_model,
-            'db_dir': vdb_dir,
-            'n_results': n_results
-        })
+    logger.info(f'using database directory: {scanner_conf.get("db_dir")}')
+    vdb = setup_vectordb(scanner_conf, embedding_conf)
 
     data_loader = Loader(vector_db=vdb)
     data_loader.load_dataset(args.dataset)

--- a/vigil/core/loader.py
+++ b/vigil/core/loader.py
@@ -1,0 +1,49 @@
+from datasets import load_dataset
+
+from loguru import logger
+
+from vigil.schema import DatasetEntry
+
+
+class Loader:
+    def __init__(self, vector_db, chunk_size=100):
+        self.vector_db = vector_db
+        self.chunk_size = chunk_size
+
+    def load_dataset(self, dataset_name: str):
+        buffer = []
+
+        logger.info(f'Loading dataset: {dataset_name}')
+        try:
+            docs_stream = load_dataset(
+                dataset_name,
+                split='train',
+                streaming=True)
+        except Exception as err:
+            logger.error(f'Error loading dataset: {err}')
+            raise
+
+        logger.info('Reading dataset stream ...')
+
+        for doc in docs_stream:
+            buffer.append(DatasetEntry(
+                text=doc['text'],
+                embeddings=doc['embeddings'],
+                metadata={'model': doc['model']}
+            ))
+            if len(buffer) >= self.chunk_size:
+                self.process_chunk(buffer)
+                buffer.clear()
+
+        if buffer:
+            self.process_chunk(buffer)
+        
+        logger.info('Finished loading dataset.')
+
+    def process_chunk(self, chunk):
+        texts = [doc.text for doc in chunk]
+        embeddings = [doc.embeddings for doc in chunk]
+        metadatas = [doc.metadata for doc in chunk]
+        self.vector_db.add_embeddings(texts, embeddings, metadatas)
+        logger.info(f'Processed chunk; {len(chunk)}')
+

--- a/vigil/schema.py
+++ b/vigil/schema.py
@@ -4,6 +4,12 @@ from typing import List, Optional, Dict
 from pydantic import BaseModel, Field
 
 
+class DatasetEntry(BaseModel):
+    text: str = ''
+    embeddings: List[float] = []
+    metadata: dict = {'model': 'unknown'}
+
+
 class ScanModel(BaseModel):
     prompt: str = ''
     prompt_response: str = None


### PR DESCRIPTION
The main `loader.py` script was re-implementing too much code related to the config parsing and vector database setup. I've created a new vigil/core/loader.py class to handle the dataset loading logic, and the main script now uses the `vigil/vigil.py` functions for setting up the vector database from the config.

Also added a new model to the schema to represent dataset rows