### PR TITLE
Scanner factory

### DIFF
--- a/vigil/__init__.py
+++ b/vigil/__init__.py
@@ -1,3 +1,10 @@
+from vigil.scanners.sentiment import SentimentScanner
+from vigil.scanners.similarity import SimilarityScanner
+from vigil.scanners.vectordb import VectorScanner
+from vigil.scanners.transformer import TransformerScanner
+from vigil.scanners.yara import YaraScanner
+
+
 __version__ = "0.9.7-alpha"
 __app__ = "vigil"
 __description__ = "LLM security scanner"

--- a/vigil/core/vectordb.py
+++ b/vigil/core/vectordb.py
@@ -3,7 +3,7 @@ import chromadb
 
 from loguru import logger
 
-from typing import List
+from typing import List, Optional
 
 from chromadb.config import Settings
 from chromadb.utils import embedding_functions
@@ -12,24 +12,32 @@ from vigil.common import uuid4_str
 
 
 class VectorDB:
-    def __init__(self, config_dict: dict):
+    def __init__(self, 
+        embed_model: str, 
+        collection_name: str, 
+        db_dir: str,
+        n_results: int, 
+        openai_key: Optional[str] = None, 
+        openai_model: Optional[str] = None
+    ):
+        """ Initialize VectorDB client """
         self.name = 'database:vector'
 
-        if config_dict['embed_fn'] == 'openai':
+        if embed_model == 'openai':
             logger.info('Using OpenAI embedding function')
             self.embed_fn = embedding_functions.OpenAIEmbeddingFunction(
-                api_key=config_dict['openai_key'],
+                api_key=openai_key,
                 model_name='text-embedding-ada-002'
             )
         else:
             logger.info(f'Using SentenceTransformer embedding function: {config_dict["embed_fn"]}')
             self.embed_fn = embedding_functions.SentenceTransformerEmbeddingFunction(
-                model_name=config_dict['embed_fn']
+                model_name=embed_model
             )
 
-        self.collection_name = config_dict['collection_name']
-        self.db_dir = config_dict['db_dir']
-        self.n_results = int(config_dict['n_results'])
+        self.collection_name = collection_name
+        self.db_dir = db_dir
+        self.n_results = n_results
 
         if not hasattr(self.embed_fn, "__call__"):
             logger.error('Embedding function is not callable')

--- a/vigil/core/vectordb.py
+++ b/vigil/core/vectordb.py
@@ -13,17 +13,16 @@ from vigil.common import uuid4_str
 
 class VectorDB:
     def __init__(self, 
-        embed_model: str, 
-        collection_name: str, 
+        model: str, 
+        collection: str, 
         db_dir: str,
         n_results: int, 
-        openai_key: Optional[str] = None, 
-        openai_model: Optional[str] = None
+        openai_key: Optional[str] = None
     ):
-        """ Initialize VectorDB client """
+        """ Initialize Chroma vector db client """
         self.name = 'database:vector'
 
-        if embed_model == 'openai':
+        if model == 'openai':
             logger.info('Using OpenAI embedding function')
             self.embed_fn = embedding_functions.OpenAIEmbeddingFunction(
                 api_key=openai_key,
@@ -32,22 +31,22 @@ class VectorDB:
         else:
             logger.info(f'Using SentenceTransformer embedding function: {config_dict["embed_fn"]}')
             self.embed_fn = embedding_functions.SentenceTransformerEmbeddingFunction(
-                model_name=embed_model
+                model_name=model
             )
 
-        self.collection_name = collection_name
+        self.collection = collection
         self.db_dir = db_dir
-        self.n_results = n_results
+        self.n_results = int(n_results)
 
         if not hasattr(self.embed_fn, "__call__"):
             logger.error('Embedding function is not callable')
-            raise ValueError('[database:vectordb] Embedding function is not a function')
+            raise ValueError('Embedding function is not a function')
 
         self.client = chromadb.PersistentClient(
             path=self.db_dir,
             settings=Settings(anonymized_telemetry=False, allow_reset=True),
         )
-        self.collection = self.get_or_create_collection(self.collection_name)
+        self.collection = self.get_or_create_collection(self.collection)
         logger.success('Loaded database')
 
     def get_or_create_collection(self, name: str):

--- a/vigil/dispatch.py
+++ b/vigil/dispatch.py
@@ -45,18 +45,17 @@ class Manager:
             else:
                 logger.info(f'{self.name} Auto-update vectordb enabled: threshold={self.update_threshold}')
 
-    def perform_scan(self, input_prompt: str, input_resp: str = None) -> dict:
+    def perform_scan(self, prompt: str, prompt_response: str = None) -> dict:
         resp = ResponseModel(
             status='success',
-            timestamp=timestamp_str(),
-            prompt=input_prompt,
-            prompt_response=input_resp,
-            prompt_entropy=calculate_entropy(input_prompt),
+            prompt=prompt,
+            prompt_response=prompt_response,
+            prompt_entropy=calculate_entropy(prompt),
         )
 
         resp.uuid = str(resp.uuid)
 
-        if not input_prompt:
+        if not prompt:
             resp.errors.append('Input prompt value is empty')
             resp.status = 'failed'
             logger.error(f'{self.name} Input prompt value is empty')
@@ -65,8 +64,8 @@ class Manager:
         logger.info(f'{self.name} Dispatching scan request id={resp.uuid}')
 
         scan_results = self.dispatcher.run(
-            input_prompt=input_prompt,
-            input_resp=input_resp,
+            prompt=prompt,
+            prompt_response=prompt_response,
             scan_id={resp.uuid}
         )
 
@@ -90,7 +89,7 @@ class Manager:
         if self.auto_update and (total_matches >= self.update_threshold):
             logger.info(f'{self.name} (auto-update) Adding detected prompt to db id={resp.uuid}')
             doc_id = self.db_client.add_texts(
-                [input_prompt],
+                [prompt],
                 [
                     {
                         'uuid': resp.uuid,
@@ -112,13 +111,13 @@ class Scanner:
         self.name = 'dispatch:scan'
         self.scanners = scanners
 
-    def run(self, input_prompt: str, scan_id: uuid.uuid4, input_resp: str = None) -> Dict:
+    def run(self, prompt: str, scan_id: uuid.uuid4, prompt_response: str = None) -> Dict:
         response = {}
 
         for scanner in self.scanners:
             scan_obj = ScanModel(
-                prompt=input_prompt,
-                prompt_response=input_resp
+                prompt=prompt,
+                prompt_response=prompt_response
             )
 
             try:

--- a/vigil/registry.py
+++ b/vigil/registry.py
@@ -1,0 +1,89 @@
+from functools import wraps
+from abc import ABC, abstractmethod
+from typing import Dict, List, Type, Callable, Optional
+
+from vigil.schema import BaseScanner
+
+
+class Registration:
+    @staticmethod
+    def scanner(name: str, requires_config=False, requires_vectordb=False, **additional_metadata):
+        def decorator(scanner_class: Type[BaseScanner]):
+            ScannerRegistry.register_scanner(name, scanner_class, requires_config, requires_vectordb, **additional_metadata)
+            return scanner_class
+        return decorator
+
+
+class ScannerRegistry:
+    _registry: Dict[str, dict] = {}
+
+    @classmethod
+    def register_scanner(
+        cls,
+        name: str,
+        scanner_class: Type[BaseScanner],
+        requires_config=False,
+        requires_vectordb=False,
+        requires_embedding=False,
+        **metadata
+    ):
+        cls._registry[name] = {
+            "class": scanner_class,
+            "requires_config": requires_config,
+            "requires_vectordb": requires_vectordb,
+            "requires_embedding": requires_embedding,
+            **metadata
+        }
+
+    @classmethod
+    def create_scanner(
+        cls,
+        name: str,
+        config: Optional[dict] = None,
+        vectordb: Optional[Callable] = None,
+        embedder: Optional[Callable] = None,
+        **params
+    ) -> BaseScanner:
+        if name not in cls._registry:
+            raise ValueError(f'No scanner registered with name: {name}')
+
+        scanner_info = cls._registry[name]
+        scanner_class = scanner_info["class"]
+
+        init_params = {}
+        if scanner_info["requires_config"]:
+            if config is None:
+                raise ValueError(f"Config required for scanner '{name}'")
+            init_params = config
+
+        if scanner_info["requires_vectordb"]:
+            if vectordb is None:
+                raise ValueError(f"VectorDB required for scanner '{name}'")
+            
+            init_params.update({"db_client": vectordb})
+        
+        if scanner_info["requires_embedding"]:
+            if embedder is None:
+                raise ValueError(f"Embedder required for scanner '{name}'")
+
+            init_params.update({"embedder": embedder})
+
+        scanner_cls = scanner_class(**init_params)
+        if hasattr(scanner_cls, "post_init"):
+            scanner_cls.post_init()
+
+        return scanner_cls
+
+    @classmethod
+    def get_scanner_names(cls) -> List[str]:
+        return list(cls._registry.keys())
+
+    @classmethod
+    def get_scanner_cls(cls) -> List[Type[BaseScanner]]:
+        return [info["class"] for info in cls._registry.values()]
+
+    @classmethod
+    def get_scanner_metadata(cls, name: str):
+        if name not in cls._registry:
+            raise ValueError(f'No scanner registered with name: {name}')
+        return cls._registry[name]

--- a/vigil/scanners/sentiment.py
+++ b/vigil/scanners/sentiment.py
@@ -14,9 +14,10 @@ nltk.download('vader_lexicon')
 
 
 class SentimentScanner(BaseScanner):
-    def __init__(self, config_dict: dict):
+    """ Sentiment analysis of a prompt and response """
+    def __init__(self, threshold: float):
         self.name = 'scanner:sentiment'
-        self.threshold = float(config_dict['threshold'])
+        self.threshold = threshold
         self.analyzer = SentimentIntensityAnalyzer()
         logger.success('Loaded scanner.')
 

--- a/vigil/scanners/sentiment.py
+++ b/vigil/scanners/sentiment.py
@@ -9,17 +9,19 @@ from vigil.schema import BaseScanner
 from vigil.schema import ScanModel
 from vigil.schema import SentimentMatch
 
+from vigil.registry import Registration
 
 nltk.download('vader_lexicon')
 
 
+@Registration.scanner(name='sentiment', requires_config=True)
 class SentimentScanner(BaseScanner):
     """ Sentiment analysis of a prompt and response """
     def __init__(self, threshold: float):
         self.name = 'scanner:sentiment'
-        self.threshold = threshold
+        self.threshold = float(threshold)
         self.analyzer = SentimentIntensityAnalyzer()
-        logger.success('Loaded scanner.')
+        logger.success('Loaded scanner')
 
     def analyze(self, scan_obj: ScanModel, scan_id: uuid.uuid4) -> ScanModel:
         logger.info(f'Performing scan; id="{scan_id}"')

--- a/vigil/scanners/similarity.py
+++ b/vigil/scanners/similarity.py
@@ -2,7 +2,7 @@ import uuid
 
 from loguru import logger
 
-from typing import Dict
+from typing import Optional
 
 from vigil.schema import BaseScanner
 from vigil.schema import ScanModel
@@ -14,12 +14,12 @@ from vigil.core.embedding import cosine_similarity
 
 class SimilarityScanner(BaseScanner):
     """ Compare the cosine similarity of the prompt and response """
-    def __init__(self, config_dict: Dict):
+    def __init__(self, model: str, threshold: float, openai_key: Optional[str] = None):
         self.name = 'scanner:response-similarity'
-        self.threshold = float(config_dict['threshold'])
+        self.threshold = threshold
         self.embedder = Embedder(
-            config_dict['model_name'],
-            config_dict['openai_key'] if 'openai_key' in config_dict else None,
+            model_name=model,
+            openai_key=openai_key,
         )
 
         logger.success('Loaded scanner.')

--- a/vigil/scanners/similarity.py
+++ b/vigil/scanners/similarity.py
@@ -2,27 +2,26 @@ import uuid
 
 from loguru import logger
 
-from typing import Optional
+from typing import Optional, Callable
 
 from vigil.schema import BaseScanner
 from vigil.schema import ScanModel
 from vigil.schema import SimilarityMatch
 
-from vigil.core.embedding import Embedder
 from vigil.core.embedding import cosine_similarity
 
+from vigil.registry import Registration
 
+
+@Registration.scanner(name='similarity', requires_config=True, requires_embedding=True)
 class SimilarityScanner(BaseScanner):
     """ Compare the cosine similarity of the prompt and response """
-    def __init__(self, model: str, threshold: float, openai_key: Optional[str] = None):
+    def __init__(self, threshold: float, embedder: Callable):
         self.name = 'scanner:response-similarity'
-        self.threshold = threshold
-        self.embedder = Embedder(
-            model_name=model,
-            openai_key=openai_key,
-        )
+        self.threshold = float(threshold)
+        self.embedder = embedder
 
-        logger.success('Loaded scanner.')
+        logger.success('Loaded scanner')
 
     def analyze(self, scan_obj: ScanModel, scan_id: uuid.uuid4) -> ScanModel:
         logger.info(f'Performing scan; id={scan_id}')

--- a/vigil/scanners/transformer.py
+++ b/vigil/scanners/transformer.py
@@ -20,7 +20,6 @@ class TransformerScanner(BaseScanner):
 
         try:
             self.pipeline = pipeline('text-classification', model=self.model_name)
-            logger.info(f'Model loaded: {self.model_name}')
         except Exception as err:
             logger.error(f'Failed to load model: {err}')
 

--- a/vigil/scanners/transformer.py
+++ b/vigil/scanners/transformer.py
@@ -10,10 +10,10 @@ from vigil.schema import BaseScanner
 
 
 class TransformerScanner(BaseScanner):
-    def __init__(self, config_dict: dict):
+    def __init__(self, model: str, threshold: float):
         self.name = 'scanner:transformer'
-        self.model_name = config_dict['model']
-        self.threshold = float(config_dict['threshold'])
+        self.model_name = model
+        self.threshold = threshold
 
         try:
             self.pipeline = pipeline('text-classification', model=self.model_name)

--- a/vigil/scanners/transformer.py
+++ b/vigil/scanners/transformer.py
@@ -8,12 +8,15 @@ from vigil.schema import ModelMatch
 from vigil.schema import ScanModel
 from vigil.schema import BaseScanner
 
+from vigil.registry import Registration
 
+
+@Registration.scanner(name='transformer', requires_config=True)
 class TransformerScanner(BaseScanner):
     def __init__(self, model: str, threshold: float):
         self.name = 'scanner:transformer'
         self.model_name = model
-        self.threshold = threshold
+        self.threshold = float(threshold)
 
         try:
             self.pipeline = pipeline('text-classification', model=self.model_name)
@@ -21,7 +24,7 @@ class TransformerScanner(BaseScanner):
         except Exception as err:
             logger.error(f'Failed to load model: {err}')
 
-        logger.success(f'Scanner loaded: {self.model_name}')
+        logger.success(f'Loaded scanner: {self.model_name}')
 
     def analyze(self, scan_obj: ScanModel, scan_id: uuid.uuid4) -> ScanModel:
         logger.info(f'Performing scan; id={scan_id}')

--- a/vigil/scanners/vectordb.py
+++ b/vigil/scanners/vectordb.py
@@ -5,22 +5,23 @@ from loguru import logger
 from vigil.schema import BaseScanner
 from vigil.schema import ScanModel
 from vigil.schema import VectorMatch
-
 from vigil.core.vectordb import VectorDB
+from vigil.registry import Registration
 
 
+@Registration.scanner(name='vectordb', requires_config=True, requires_vectordb=True)
 class VectorScanner(BaseScanner):
     def __init__(self, db_client: VectorDB, threshold: float):
         self.name = 'scanner:vectordb'
-        self.database = db_client
-        self.threshold = threshold
-        logger.success('Loaded scanner.')
+        self.db_client = db_client
+        self.threshold = float(threshold)
+        logger.success('Loaded scanner')
 
     def analyze(self, scan_obj: ScanModel, scan_id: uuid.uuid4) -> ScanModel:
         logger.info(f'Performing scan; id="{scan_id}"')
 
         try:
-            matches = self.database.query(scan_obj.prompt)
+            matches = self.db_client.query(scan_obj.prompt)
         except Exception as err:
             logger.error(f'Failed to perform vector scan; id="{scan_id}" error="{err}"')
             return scan_obj
@@ -31,7 +32,6 @@ class VectorScanner(BaseScanner):
             distance = match[2]
 
             if distance < self.threshold and match[0] not in existing_texts:
-                # with chromadb a lower distance means the vectors are more similar
                 m = VectorMatch(text=match[0], metadata=match[1], distance=match[2])
                 logger.warning(f'Matched vector text="{m.text}" threshold="{self.threshold}" distance="{m.distance}" id="{scan_id}"')
                 scan_obj.results.append(m)

--- a/vigil/scanners/vectordb.py
+++ b/vigil/scanners/vectordb.py
@@ -6,12 +6,14 @@ from vigil.schema import BaseScanner
 from vigil.schema import ScanModel
 from vigil.schema import VectorMatch
 
+from vigil.core.vectordb import VectorDB
+
 
 class VectorScanner(BaseScanner):
-    def __init__(self, config_dict: dict, db_client):
+    def __init__(self, db_client: VectorDB, threshold: float):
         self.name = 'scanner:vectordb'
         self.database = db_client
-        self.threshold = config_dict['threshold']
+        self.threshold = threshold
         logger.success('Loaded scanner.')
 
     def analyze(self, scan_obj: ScanModel, scan_id: uuid.uuid4) -> ScanModel:

--- a/vigil/scanners/yara.py
+++ b/vigil/scanners/yara.py
@@ -11,9 +11,9 @@ from vigil.schema import BaseScanner
 
 
 class YaraScanner(BaseScanner):
-    def __init__(self, config_dict: dict):
+    def __init__(self, rules_dir: str):
         self.name = 'scanner:yara'
-        self.rules_dir = config_dict['rules_dir']
+        self.rules_dir = rules_dir
         self.compiled_rules = None
 
         if not os.path.exists(self.rules_dir):

--- a/vigil/schema.py
+++ b/vigil/schema.py
@@ -45,6 +45,10 @@ class BaseScanner(ABC):
     def analyze(self, scan_obj: ScanModel, scan_id: UUID = uuid4()) -> ScanModel:
         raise NotImplementedError('This method needs to be overridden in the subclass.')
 
+    def post_init(self):
+        """ Optional post-initialization method """
+        pass
+
 
 class VectorMatch(BaseModel):
     text: str = ''

--- a/vigil/vigil.py
+++ b/vigil/vigil.py
@@ -10,63 +10,85 @@ from vigil.schema import BaseScanner
 from vigil.core.config import Config
 from vigil.core.canary import CanaryTokens
 from vigil.core.vectordb import VectorDB
+from vigil.core.embedding import Embedder
 
-from vigil.scanners.yara import YaraScanner
-from vigil.scanners.vectordb import VectorScanner
-from vigil.scanners.transformer import TransformerScanner
-from vigil.scanners.similarity import SimilarityScanner
-from vigil.scanners.sentiment import SentimentScanner
+from vigil.registry import ScannerRegistry
 
 
 class Vigil:
     vectordb: Optional[VectorDB] = None
+    embedder: Optional[Callable] = None
 
     def __init__(self, config_path: str):
-        self.input_scanner: Optional[Manager] = None
-        self.output_scanner: Optional[Manager] = None
+        self._config = Config(config_path)
+        self._initialize_vectordb()
+        self._initialize_embedder()
+        
+        self._input_scanners: List[BaseScanner] = self._setup_scanners(
+            self._config.get_scanner_names('input_scanners')
+        )
+        self._output_scanners: List[BaseScanner] = self._setup_scanners(
+            self._config.get_scanner_names('output_scanners')
+        )
+
         self.canary_tokens = CanaryTokens()
-
-        self.config = Config(config_path)
-        self._input_scanners: List[BaseScanner] = []
-        self._output_scanners: List[BaseScanner] = []
-        self._setup_from_config()
-
-    @classmethod
-    def _set_vectordb(cls, vectordb_instance):
-        cls.vectordb = vectordb_instance
-
-    def _setup_from_config(self):
-        self._input_scanners = self._setup_scanners(
-            self.config.get_scanner_names('input_scanners')
+        self.input_scanner = self._create_manager(
+            name='input',
+            scanners=self._input_scanners
         )
-        self._output_scanners = self._setup_scanners(
-            self.config.get_scanner_names('output_scanners')
+        self.output_scanner = self._create_manager(
+            name='output',
+            scanners=self._output_scanners
         )
-        self.input_scanner = self._create_manager('input_scanners', self._input_scanners)
-        self.output_scanner = self._create_manager('output_scanners', self._output_scanners)
+
+    def _initialize_embedder(self):
+        full_config = self._config.get_general_config()
+        params = full_config.get('embedding', {})
+        self.embedder = Embedder(**params)
+
+    def _initialize_vectordb(self):
+        full_config = self._config.get_general_config()
+        params = full_config.get('vectordb', {})
+        params.update(full_config.get('embedding', {}))
+        self.vectordb = VectorDB(**params)
 
     def _setup_scanners(self, scanner_names: List[str]) -> List[BaseScanner]:
         scanners = []
 
         for name in scanner_names:
-            setup_fn = SCANNER_SETUPS.get(name)
-            if not setup_fn:
-                raise ValueError(f'Unsupported scanner set in config: {name}')
+            try:
+                metadata = ScannerRegistry.get_scanner_metadata(name)
+            except ValueError as err:
+                logger.error(err)
+                raise err
 
-            scanner_config = self.config.get_scanner_config(name)
-            if name == 'vectordb' or name == 'similarity':
-                embedding_conf = self.config.get_general_config().get('embedding', {})
-                scanner = setup_fn(scanner_config, embedding_conf)
-            else:
-                scanner = setup_fn(scanner_config)
+            scanner_config = None
+            vectordb = None
+            embedder = None
+
+            if metadata.get('requires_config', False):
+                scanner_config = self._config.get_scanner_config(name)
+
+            if metadata.get('requires_vectordb', False):
+                vectordb = self.vectordb
+            
+            if metadata.get('requires_embedding', False):
+                embedder = self.embedder
+
+            scanner = ScannerRegistry.create_scanner(
+                name=name,
+                config=scanner_config,
+                vectordb=vectordb,
+                embedder=embedder
+            )
             scanners.append(scanner)
 
         return scanners
 
     def _create_manager(self, name: str, scanners: List[BaseScanner]) -> Manager:
-        manager_config = self.config.get_general_config() if self.config else {}
-        auto_update = manager_config.get('embedding', {}).get('auto_update', False)
-        update_threshold = int(manager_config.get('embedding', {}).get('update_threshold', 3))
+        manager_config = self._config.get_general_config()
+        auto_update = manager_config.get('auto_update', {}).get('enabled', False)
+        update_threshold = int(manager_config.get('auto_update', {}).get('threshold', 3))
 
         return Manager(
             name=name,
@@ -79,115 +101,3 @@ class Vigil:
     @staticmethod
     def from_config(config_path: str) -> 'Vigil':
         return Vigil(config_path=config_path)
-
-
-def setup_yara_scanner(conf) -> BaseScanner:
-    yara_dir = conf['rules_dir']
-    if yara_dir is None:
-        logger.error('No yara rules directory set in config')
-        raise ValueError('No yara rules directory set in config')
-
-    yara_scanner = YaraScanner(rules_dir=yara_dir)
-    yara_scanner.load_rules()
-    return yara_scanner
-
-
-def setup_sentiment_scanner(conf) -> BaseScanner:
-    threshold = float(conf['threshold'])
-    return SentimentScanner(threshold=threshold)
-
-
-def setup_vectordb(scanner_conf, embedding_conf) -> BaseScanner:
-    vdb_dir = scanner_conf['db_dir']
-    vdb_collection = scanner_conf['collection']
-    vdb_threshold = scanner_conf['threshold']
-    vdb_n_results = scanner_conf['n_results']
-
-    if not os.path.isdir(vdb_dir):
-        logger.error(f'VectorDB directory not found: {vdb_dir}')
-        raise ValueError(f'VectorDB directory not found: {vdb_dir}')
-
-    emb_model = embedding_conf['model']
-    if emb_model is None:
-        logger.error('No embedding model set in config file')
-        raise ValueError('No embedding model set in config file')
-
-    if emb_model == 'openai':
-        openai_key = embedding_conf['openai_api_key']
-        openai_model = embedding_conf['openai_model']
-
-        if openai_key is None or openai_model is None:
-            logger.error('OpenAI embedding model selected but no key or model name set in config')
-            raise ValueError('OpenAI embedding model selected but no key or model name set in config')
-
-        vectordb = VectorDB(
-                embed_model='openai',
-                collection_name=vdb_collection,
-                db_dir=vdb_dir,
-                n_results=int(vdb_n_results),
-                openai_key=openai_key,
-                openai_model=openai_model
-            )
-
-    else:
-        vectordb = VectorDB(
-                embed_model=emb_model,
-                collection_name=vdb_collection,
-                db_dir=vdb_dir,
-                n_results=int(vdb_n_results)
-            )
-    
-    return vectordb
-
-
-def setup_vectordb_scanner(scanner_conf, embedding_conf) -> BaseScanner:
-    vectordb = setup_vectordb(scanner_conf, embedding_conf)
-
-    Vigil._set_vectordb(vectordb)
-
-    return VectorScanner(
-        db_client=vectordb,
-        threshold=float(scanner_conf['threshold'])
-    )
-
-
-def setup_similarity_scanner(scanner_conf, embedding_conf) -> BaseScanner:
-    sim_threshold = scanner_conf['threshold']
-    emb_model = embedding_conf['model']
-
-    if not sim_threshold or not emb_model:
-        logger.error('Missing configurations for Similarity Scanner')
-        raise ValueError('Missing configurations for Similarity Scanner')
-
-    openai_key = None
-    if emb_model == 'openai':
-        openai_key = embedding_conf['openai_api_key']
-
-    return SimilarityScanner(
-        model=emb_model,
-        threshold=float(sim_threshold),
-        openai_key=openai_key
-    )
-
-
-def setup_transformer_scanner(conf) -> BaseScanner:
-    lm_name = conf['model']
-    threshold = conf['threshold']
-
-    if not lm_name or not threshold:
-        logger.error('Missing configurations for Transformer Scanner')
-        raise ValueError('Missing configurations for Transformer Scanner')
-
-    return TransformerScanner(
-        model=lm_name,
-        threshold=float(threshold)
-    )
-
-
-SCANNER_SETUPS: Dict[str, Callable] = {
-    'yara': setup_yara_scanner,
-    'sentiment': setup_sentiment_scanner,
-    'vectordb': setup_vectordb_scanner,
-    'similarity': setup_similarity_scanner,
-    'transformer': setup_transformer_scanner
-}


### PR DESCRIPTION
* Change scan status to use an Enum
* Scanners are initialized with keyword arguments, instead of the dictionary of kwargs they were previously passed
* Implement factory pattern to register and create scanner classes
* Add post_init hook for scanners to optionally use
* Decorator for registering scanners
    * `requires_vectordb`, `requires_config`, and `requires_embedding` can be specified for that scanner to receive additional options and classes it can use
* Remove some overly verbose log messages

Addresses https://github.com/deadbits/vigil-llm/issues/61 and https://github.com/deadbits/vigil-llm/issues/62