### PR TITLE
Update detections.md to reference the correct yara rules directory

### DIFF
--- a/docs/detections.md
+++ b/docs/detections.md
@@ -14,7 +14,7 @@ The `vectordb` scanner uses a [vector database](https://github.com/chroma-core/c
 All embeddings are available on HuggingFace and listed in the `Datasets` section of this document. 
 
 ### Heuristics
-The `yara` scanner and the accompanying [rules](data/yara/) act as heuristics detection. Submitted prompts are scanned against the rulesets with matches raised as potential prompt injection.
+The `yara` scanner and the accompanying [rules](../data/yara/) act as heuristics detection. Submitted prompts are scanned against the rulesets with matches raised as potential prompt injection.
 
 Custom rules can be used by adding them to the `data/yara` directory.
 


### PR DESCRIPTION
The current link results in a 404.  The relative link to the yara detection directory fails as the yara detection library's parent (data) is located one folder up from this document's location, not in the current doc's directory.