### PR TITLE
Update Dockerfile to greatly minimize final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.10-slim
 WORKDIR /app
 
 # Install the necessary build tools, dependencies, git, git-lfs, and YARA prerequisites
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
     automake \
     autoconf \
     build-essential \


### PR DESCRIPTION
When you don't use apt-get's --no-install-recommends flag, you install all the recommended packages for the package and the package itself. By implementing this parameter, I was able to decrease my image size by ~20% on my various arch. builds.  I haven't calculated the build time savings yet. 

An older reference to why this can be meaningful for this project - https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends .
