### PR TITLE
remove urllib3 library as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-urllib3==1.26.7
 openai==1.0.0
 transformers==4.30.0
 pydantic==1.10.7

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         'openai==1.0.0',
-        'urllib3==1.26.7',
         'transformers==4.30.0',
         'pydantic==1.10.7',
         'Flask==3.0.0',


### PR DESCRIPTION
The pinned version of urllib3 was an outdated / vulnerable package. I'm pretty sure the vulnerable code wasn't used anywhere in this app, but just to make things easier I've removed the urllib3 requirement entirely and it is now correctly installed as a dependency of chromadb.

I think I originally pinned it due to some conflict that was resolved when I bumped the chromadb version a few weeks back.