### PR TITLE
Change default model to laiyer/deberta-v3-base-prompt-injection

### DIFF
--- a/conf/server.conf
+++ b/conf/server.conf
@@ -26,7 +26,7 @@ rules_dir = /home/vigil/vigil-llm/data/yara
 threshold = 0.4
 
 [scanner:transformer]
-model = deepset/deberta-v3-base-injection
+model = laiyer/deberta-v3-base-prompt-injection
 threshold = 0.98
 
 [scanner:similarity]


### PR DESCRIPTION
Change the default transformer model to use https://huggingface.co/laiyer/deberta-v3-base-prompt-injection instead of deepset/deberta-v3-base-injection

This only required a config file change as the new models output uses the same format as the old.

Loss: 0.0010
Accuracy: 0.9999
Recall: 0.9997
Precision: 0.9998
F1: 0.9998

Addresses https://github.com/deadbits/vigil-llm/issues/66